### PR TITLE
Hero image customisation

### DIFF
--- a/documentation/site.md
+++ b/documentation/site.md
@@ -20,6 +20,9 @@ The top section of the homepage (hero section) can be fully customised through t
    - **Hero Section Width**: Adjust the width of the content area (50–100%)
    - **Hero Button Text**: The text displayed on the call-to-action button
    - **Hero Button URL**: Where the button links to (can be an internal page or external URL)
+   - **Hero Foreground Image**: Upload an image to display as a content element within the hero section, separate from the background.
+   - **Hero Image Position**: Choose whether to display the foreground image above or below the text content.
+   - **Hero Image Max Width (%)**: Set the maximum width of the foreground image as a percentage of the hero section width.
 3. Changes will be visible in the preview and will go live when you click "Publish"
 
 ### Featured Home Posts

--- a/documentation/theme.md
+++ b/documentation/theme.md
@@ -62,6 +62,9 @@ These settings can be managed via **Appearance → Customise → Archive Setting
 
 The front page (`front-page.php`) is designed for flexibility:
 - **Hero Section**: Fully customisable with heading, text, background image/colour, overlay, button text, and URL.
+- **Hero Foreground Image**: Allows you to upload an image to display as a content element within the hero section, separate from the background.
+- **Hero Image Position**: Choose whether to display the foreground image above or below the text content.
+- **Hero Image Max Width (%)**: Set the maximum width of the foreground image as a percentage of the hero section width.
 - **Home Category Posts**: Displays up to six most recent posts from the **home** category in a grid layout.
 - **Features Section**: Placeholder area for additional content.
 

--- a/footer.php
+++ b/footer.php
@@ -44,10 +44,6 @@
         
         <div class="site-info">
             <?php echo wp_kses_post(get_theme_mod('footer_text', 'Copyright © ' . date('Y') . ' ' . get_bloginfo('name'))); ?>
-            
-            <div class="ai-attribution">
-                <?php echo wp_kses_post(get_theme_mod('ai_attribution_text', 'Original idea, code generated with AI assistance.')); ?>
-            </div>
         </div><!-- .site-info -->
     </footer><!-- #colophon -->
 </div><!-- #page -->

--- a/front-page.php
+++ b/front-page.php
@@ -27,44 +27,14 @@ get_header();
             $hero_position = get_theme_mod('hero_image_position', 'below');
             $has_hero_image = get_theme_mod('hero_foreground_image');
             
-            // If image position is left, show it before text
-            if ($has_hero_image && $hero_position === 'left') : ?>
-                <div class="hero-content-wrapper hero-layout-<?php echo esc_attr($hero_position); ?>">
-                    <div class="hero-image">
-                        <img src="<?php echo esc_url(get_theme_mod('hero_foreground_image')); ?>" alt="<?php echo esc_attr(get_theme_mod('hero_heading', 'Hero Image')); ?>" style="max-width: <?php echo esc_attr(get_theme_mod('hero_image_max_width', '80')); ?>%;">
-                    </div>
-                    <div class="hero-text-content">
-                        <h1><?php echo esc_html(get_theme_mod('hero_heading', 'Welcome to Our Website')); ?></h1>
-                        <p><?php echo esc_html(get_theme_mod('hero_text', 'This is your custom homepage. Add your content here.')); ?></p>
-                        
-                        <?php if (get_theme_mod('hero_button_text')) : ?>
-                            <a href="<?php echo esc_url(get_theme_mod('hero_button_url', '#')); ?>" class="hero-button">
-                                <?php echo esc_html(get_theme_mod('hero_button_text', 'Learn More')); ?>
-                            </a>
-                        <?php endif; ?>
-                    </div>
+            // If image position is above, show it first
+            if ($has_hero_image && $hero_position === 'above') : ?>
+                <div class="hero-image">
+                    <img src="<?php echo esc_url(get_theme_mod('hero_foreground_image')); ?>" alt="<?php echo esc_attr(get_theme_mod('hero_heading', 'Hero Image')); ?>" style="max-width: <?php echo esc_attr(get_theme_mod('hero_image_max_width', '80')); ?>%;">
                 </div>
-            <?php 
-            // If image position is right, show text first then image
-            elseif ($has_hero_image && $hero_position === 'right') : ?>
-                <div class="hero-content-wrapper hero-layout-<?php echo esc_attr($hero_position); ?>">
-                    <div class="hero-text-content">
-                        <h1><?php echo esc_html(get_theme_mod('hero_heading', 'Welcome to Our Website')); ?></h1>
-                        <p><?php echo esc_html(get_theme_mod('hero_text', 'This is your custom homepage. Add your content here.')); ?></p>
-                        
-                        <?php if (get_theme_mod('hero_button_text')) : ?>
-                            <a href="<?php echo esc_url(get_theme_mod('hero_button_url', '#')); ?>" class="hero-button">
-                                <?php echo esc_html(get_theme_mod('hero_button_text', 'Learn More')); ?>
-                            </a>
-                        <?php endif; ?>
-                    </div>
-                    <div class="hero-image">
-                        <img src="<?php echo esc_url(get_theme_mod('hero_foreground_image')); ?>" alt="<?php echo esc_attr(get_theme_mod('hero_heading', 'Hero Image')); ?>" style="max-width: <?php echo esc_attr(get_theme_mod('hero_image_max_width', '80')); ?>%;">
-                    </div>
-                </div>
-            <?php
-            // Default layout (below or no image)
-            else : ?>
+            <?php endif; ?>
+            
+            <div class="hero-text-content">
                 <h1><?php echo esc_html(get_theme_mod('hero_heading', 'Welcome to Our Website')); ?></h1>
                 <p><?php echo esc_html(get_theme_mod('hero_text', 'This is your custom homepage. Add your content here.')); ?></p>
                 
@@ -73,12 +43,12 @@ get_header();
                         <?php echo esc_html(get_theme_mod('hero_button_text', 'Learn More')); ?>
                     </a>
                 <?php endif; ?>
-                
-                <?php if ($has_hero_image && $hero_position === 'below') : ?>
-                    <div class="hero-image">
-                        <img src="<?php echo esc_url(get_theme_mod('hero_foreground_image')); ?>" alt="<?php echo esc_attr(get_theme_mod('hero_heading', 'Hero Image')); ?>" style="max-width: <?php echo esc_attr(get_theme_mod('hero_image_max_width', '80')); ?>%;">
-                    </div>
-                <?php endif; ?>
+            </div>
+            
+            <?php if ($has_hero_image && $hero_position === 'below') : ?>
+                <div class="hero-image">
+                    <img src="<?php echo esc_url(get_theme_mod('hero_foreground_image')); ?>" alt="<?php echo esc_attr(get_theme_mod('hero_heading', 'Hero Image')); ?>" style="max-width: <?php echo esc_attr(get_theme_mod('hero_image_max_width', '80')); ?>%;">
+                </div>
             <?php endif; ?>
         </div>
     </section>

--- a/front-page.php
+++ b/front-page.php
@@ -22,13 +22,63 @@ get_header();
             style="background-color: <?php echo esc_attr(get_theme_mod('hero_bg_color', '#f8f9fa')); ?>;"
         <?php endif; ?>>
         <div class="container" style="max-width: <?php echo esc_attr(get_theme_mod('hero_width', '100')); ?>%; text-align: <?php echo esc_attr(get_theme_mod('hero_text_align', 'center')); ?>; color: <?php echo esc_attr(get_theme_mod('hero_text_color', '#333333')); ?>;">
-            <h1><?php echo esc_html(get_theme_mod('hero_heading', 'Welcome to Our Website')); ?></h1>
-            <p><?php echo esc_html(get_theme_mod('hero_text', 'This is your custom homepage. Add your content here.')); ?></p>
             
-            <?php if (get_theme_mod('hero_button_text')) : ?>
-                <a href="<?php echo esc_url(get_theme_mod('hero_button_url', '#')); ?>" class="hero-button">
-                    <?php echo esc_html(get_theme_mod('hero_button_text', 'Learn More')); ?>
-                </a>
+            <?php 
+            $hero_position = get_theme_mod('hero_image_position', 'below');
+            $has_hero_image = get_theme_mod('hero_foreground_image');
+            
+            // If image position is left, show it before text
+            if ($has_hero_image && $hero_position === 'left') : ?>
+                <div class="hero-content-wrapper hero-layout-<?php echo esc_attr($hero_position); ?>">
+                    <div class="hero-image">
+                        <img src="<?php echo esc_url(get_theme_mod('hero_foreground_image')); ?>" alt="<?php echo esc_attr(get_theme_mod('hero_heading', 'Hero Image')); ?>" style="max-width: <?php echo esc_attr(get_theme_mod('hero_image_max_width', '80')); ?>%;">
+                    </div>
+                    <div class="hero-text-content">
+                        <h1><?php echo esc_html(get_theme_mod('hero_heading', 'Welcome to Our Website')); ?></h1>
+                        <p><?php echo esc_html(get_theme_mod('hero_text', 'This is your custom homepage. Add your content here.')); ?></p>
+                        
+                        <?php if (get_theme_mod('hero_button_text')) : ?>
+                            <a href="<?php echo esc_url(get_theme_mod('hero_button_url', '#')); ?>" class="hero-button">
+                                <?php echo esc_html(get_theme_mod('hero_button_text', 'Learn More')); ?>
+                            </a>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            <?php 
+            // If image position is right, show text first then image
+            elseif ($has_hero_image && $hero_position === 'right') : ?>
+                <div class="hero-content-wrapper hero-layout-<?php echo esc_attr($hero_position); ?>">
+                    <div class="hero-text-content">
+                        <h1><?php echo esc_html(get_theme_mod('hero_heading', 'Welcome to Our Website')); ?></h1>
+                        <p><?php echo esc_html(get_theme_mod('hero_text', 'This is your custom homepage. Add your content here.')); ?></p>
+                        
+                        <?php if (get_theme_mod('hero_button_text')) : ?>
+                            <a href="<?php echo esc_url(get_theme_mod('hero_button_url', '#')); ?>" class="hero-button">
+                                <?php echo esc_html(get_theme_mod('hero_button_text', 'Learn More')); ?>
+                            </a>
+                        <?php endif; ?>
+                    </div>
+                    <div class="hero-image">
+                        <img src="<?php echo esc_url(get_theme_mod('hero_foreground_image')); ?>" alt="<?php echo esc_attr(get_theme_mod('hero_heading', 'Hero Image')); ?>" style="max-width: <?php echo esc_attr(get_theme_mod('hero_image_max_width', '80')); ?>%;">
+                    </div>
+                </div>
+            <?php
+            // Default layout (below or no image)
+            else : ?>
+                <h1><?php echo esc_html(get_theme_mod('hero_heading', 'Welcome to Our Website')); ?></h1>
+                <p><?php echo esc_html(get_theme_mod('hero_text', 'This is your custom homepage. Add your content here.')); ?></p>
+                
+                <?php if (get_theme_mod('hero_button_text')) : ?>
+                    <a href="<?php echo esc_url(get_theme_mod('hero_button_url', '#')); ?>" class="hero-button">
+                        <?php echo esc_html(get_theme_mod('hero_button_text', 'Learn More')); ?>
+                    </a>
+                <?php endif; ?>
+                
+                <?php if ($has_hero_image && $hero_position === 'below') : ?>
+                    <div class="hero-image">
+                        <img src="<?php echo esc_url(get_theme_mod('hero_foreground_image')); ?>" alt="<?php echo esc_attr(get_theme_mod('hero_heading', 'Hero Image')); ?>" style="max-width: <?php echo esc_attr(get_theme_mod('hero_image_max_width', '80')); ?>%;">
+                    </div>
+                <?php endif; ?>
             <?php endif; ?>
         </div>
     </section>

--- a/functions.php
+++ b/functions.php
@@ -453,9 +453,8 @@ function team1_theme_customize_register( $wp_customize ) {
         'type'     => 'select',
         'priority' => 16,
         'choices'  => array(
-            'below'  => __('Below Text', 'team1theme'),
-            'right'  => __('Right of Text', 'team1theme'),
-            'left'   => __('Left of Text', 'team1theme'),
+            'above' => __('Above Text', 'team1theme'),
+            'below' => __('Below Text', 'team1theme'),
         ),
     ));
 

--- a/functions.php
+++ b/functions.php
@@ -425,6 +425,59 @@ function team1_theme_customize_register( $wp_customize ) {
         'section'  => 'homepage_settings',
         'type'     => 'url',
     ) );
+
+    // Hero Foreground Image
+    $wp_customize->add_setting('hero_foreground_image', array(
+        'default'           => '',
+        'sanitize_callback' => 'esc_url_raw',
+        'transport'         => 'refresh',
+    ));
+
+    $wp_customize->add_control(new WP_Customize_Image_Control($wp_customize, 'hero_foreground_image', array(
+        'label'       => __('Hero Foreground Image', 'team1theme'),
+        'description' => __('This image appears in the hero section as content (not as background)', 'team1theme'),
+        'section'     => 'homepage_settings',
+        'priority'    => 15,
+    )));
+
+    // Hero Image Position
+    $wp_customize->add_setting('hero_image_position', array(
+        'default'           => 'below',
+        'sanitize_callback' => 'sanitize_text_field',
+        'transport'         => 'refresh',
+    ));
+
+    $wp_customize->add_control('hero_image_position', array(
+        'label'    => __('Hero Image Position', 'team1theme'),
+        'section'  => 'homepage_settings',
+        'type'     => 'select',
+        'priority' => 16,
+        'choices'  => array(
+            'below'  => __('Below Text', 'team1theme'),
+            'right'  => __('Right of Text', 'team1theme'),
+            'left'   => __('Left of Text', 'team1theme'),
+        ),
+    ));
+
+    // Hero Image Max Width
+    $wp_customize->add_setting('hero_image_max_width', array(
+        'default'           => '80',
+        'sanitize_callback' => 'absint',
+        'transport'         => 'refresh',
+    ));
+
+    $wp_customize->add_control('hero_image_max_width', array(
+        'label'       => __('Hero Image Max Width (%)', 'team1theme'),
+        'description' => __('Maximum width of the hero image', 'team1theme'),
+        'section'     => 'homepage_settings',
+        'type'        => 'range',
+        'priority'    => 17,
+        'input_attrs' => array(
+            'min'  => 20,
+            'max'  => 100,
+            'step' => 5,
+        ),
+    ));
 }
 add_action( 'customize_register', 'team1_theme_customize_register' );
 


### PR DESCRIPTION
@Reece-Kelly @KeziahF 

I have added custom settings for the frontpage:

1. Go to **Appearance → Customise → Homepage Settings**
   **- **Hero Foreground Image**: Upload an image to display as a content element within the hero section, separate from the background.
   - **Hero Image Position**: Choose whether to display the foreground image above or below the text content.
   - **Hero Image Max Width (%)**: Set the maximum width of the foreground image as a percentage of the hero section width.**